### PR TITLE
FIX: cmake build on external projects

### DIFF
--- a/scripts/gen_vinstr.sh
+++ b/scripts/gen_vinstr.sh
@@ -1,9 +1,9 @@
 CMAKE_CXX_COMPILER=$1
-CMAKE_SOURCE_DIR=$2
+CMAKE_CURRENT_SOURCE_DIR=$2
 CMAKE_CURRENT_BINARY_DIR=$3
 
-${CMAKE_CXX_COMPILER} -emit-llvm -S ${CMAKE_SOURCE_DIR}/src/pass/codegen/vinstr.cpp \
-                   -I ${CMAKE_SOURCE_DIR}/include/ \
+${CMAKE_CXX_COMPILER} -emit-llvm -S ${CMAKE_CURRENT_SOURCE_DIR}/pass/codegen/vinstr.cpp \
+                   -I ${CMAKE_CURRENT_SOURCE_DIR}/../include/ \
                    -o ${CMAKE_CURRENT_BINARY_DIR}/vinstr.ll
 
 VINSTR_IR=$(cat ${CMAKE_CURRENT_BINARY_DIR}/vinstr.ll)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,8 +14,8 @@ set(SRC_FILES
 # execute_process is for configure (cmake) and target is for build (make)
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/vinstr_str.cpp
-    COMMAND bash ${CMAKE_SOURCE_DIR}/scripts/gen_vinstr.sh ${CMAKE_CXX_COMPILER} ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${CMAKE_SOURCE_DIR}/src/pass/codegen/vinstr.cpp
+    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/gen_vinstr.sh ${CMAKE_CXX_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS pass/codegen/vinstr.cpp
 )
 
 add_library(tilt STATIC ${SRC_FILES} ${CMAKE_CURRENT_BINARY_DIR}/vinstr_str.cpp)


### PR DESCRIPTION
tilt build failing on external project
Using correct directory path